### PR TITLE
rondelli apply 12 patches

### DIFF
--- a/libexplain/buffer/termiox.h
+++ b/libexplain/buffer/termiox.h
@@ -21,7 +21,11 @@
 
 #include <libexplain/string_buffer.h>
 
-struct termiox; /* forward */
+/* make termiox empty
+   no more defined in Linux kernel since 5.12:
+   https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v5.12&id=c762a2b846b619c0f92f23e2e8e16f70d20df800
+ */
+struct termiox {};
 
 /**
   * The explain_buffer_termiox function may be used

--- a/libexplain/buffer/termiox.h
+++ b/libexplain/buffer/termiox.h
@@ -23,12 +23,6 @@
 
 struct termiox; /* forward */
 
-// GAIA-PATCH: define termiox struct that is otherwise not
-// found in Linux Kernel 5.11.
-struct termiox {
-
-};
-
 /**
   * The explain_buffer_termiox function may be used
   * to print a representation of a termiox structure.

--- a/script/test_prelude.sh.in
+++ b/script/test_prelude.sh.in
@@ -113,7 +113,7 @@ test $? -eq 0 || no_result
 # diff things differs.  And it does, by a carriage return.
 if diff --strip-trailing-cr /dev/null /dev/null > /dev/null 2>&1
 then
-    diffpath=`which diff`
+    diffpath=`command -v diff`
     diff() {
         $diffpath --strip-trailing-cr "$@"
     }


### PR DESCRIPTION
- Revert "Workaround for undefined struct termiox on Linux 5.11"
- termiox no more exists since kernel 5.12
- use command -v
